### PR TITLE
Execute on current working directory for console applications

### DIFF
--- a/shim.cpp
+++ b/shim.cpp
@@ -184,8 +184,9 @@ All other argument are passed to the parent executable.
                         (alias --shimgen-gui)
 
     --shim-UseTargetWorkingDirectory
-                    Set the working directory to the target path. By default
-                        the application will use the shim's path. Useful when
+                    Set the working directory to the target path. By default 
+                        the application will use the shim's path for GUI and 
+                        shell current path for console. This option is useful when
                         programs need to be running from where they are located
                         (usually indicates programs that have issues being run
                         globally).
@@ -337,7 +338,10 @@ int ShimMain() {
     appArgs += L" ";
   appArgs += calling_args;
 
-  wstring working_dir = shimArgUseTarget ? appDir : shimDir;
+  // for console application, set wd to where the shim was called from
+  wstring fallback_dir = shimType == L"CONSOLE" ? currDir : shimDir;
+
+  wstring working_dir = shimArgUseTarget ? appDir : fallback_dir;
   
   
   


### PR DESCRIPTION
I was recently puzzling over how to add a single executable file to the PATH and ran into a bit of trouble. I tried using symlinks and bat files, but eventually stumbled upon the shim solution. Just as I was about to roll up my sleeves and reinvent the wheel, I came across your repository. It’s exactly what I was trying to achieve, and the quality is top-notch. Thank you so much for sharing it! 😊

Anyway, back to the point—I noticed a small issue while using the console shim: when running it, the working directory (CWD) gets set to the shim’s location. This means relative paths are resolved relative to the shim’s directory, not the terminal’s current directory.

For example, I created a shim for java.exe, but when I tried running `java Main.java` with a relative path, it couldn’t find the file unless I provided the full path.

Here is an example:

```console
$ .\shim_exec.exe --path 'C:\Users\enihsyou\AppData\Local\Programs\GoLand\jbr\bin\java.exe' --output 'C:\Users\enihsyou\.local\bin\java.exe'
SHIM_EXEC has successfully created 'C:\Users\enihsyou\.local\bin\java.exe'

$ cd C:\Users\enihsyou\dotfiles\Windows
$ echo "some hello world code" > Main.java
$ java Main.java
java.lang.ClassNotFoundException: Main.java

$ java --shim-noop Main.java
===============================================================================
JAVA.EXE - SHIM
===============================================================================
This is a shim for JAVA.EXE built with SHIM EXECUTABLE (v2.3.0)
See https://github.com/jphilbert/shim_executable for additional information

Shim Path:      'C:\Users\enihsyou\.local\bin'
Current Path:   'C:\Users\enihsyou\dotfiles\Windows'
...
Embedded Parameters:
  Shim Type:    CONSOLE
  App Name:     'java'
  App Path:     'C:\Users\enihsyou\AppData\Local\Programs\GoLand\jbr\bin'
  App Args:     <NONE>
...
Creating process for application
  APP: 'C:\Users\enihsyou\AppData\Local\Programs\GoLand\jbr\bin\java.exe'
  ARG: 'Main.java'
  DIR: 'C:\Users\enihsyou\.local\bin'

$ mv Main.java C:\Users\enihsyou\.local\bin
$ java Main.java
Hello, World!
```

The same issue pops up with other terminal applications like `jq` and `hurl` installed by winget. Their CWD should match the terminal’s current directory, not the shim’s.

To fix this, I made a small tweak: for CLI applications, I set the CWD to the terminal’s current directory by default; for GUI applications, I kept the original behavior where the CWD is the shim’s directory. This shouldn’t affect programs that rely on DLLs.

I can’t think of any practical use case for having the CWD default to the shim’s directory. If you have any scenarios where this might be handy, please enlighten me! 🙏

Since the Issue section of this repo is closed, I’ve submitted this change as a Pull Request.

On top of that, I also wrote a GitHub Action to automate the build process. If you think it’s useful, I’d be happy to submit it in a separate PR. Looking forward to your thoughts! 
